### PR TITLE
Simplify engine interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,160 @@ Hewn is a primitive Rust game engine for learning and tinkering, with Terminal a
 - Crate: [crates.io/hewn](https://crates.io/crates/hewn)
 - Examples: `examples/asciijump`, `examples/asciibird`, `examples/snake`
 
-Quick start:
+## Quick start
+
+The following is a minimal example of a game in Hewn, allowing a player to move a character around the screen in a terminal.
+
+```rust
+use hewn::game::{Entities, GameLogic};
+use hewn::game_object::{CollisionBox, Coordinate, GameObject};
+use hewn::runtime::{initialize_terminal_io, Key, TerminalRuntime};
+use hewn::view::cursor::StaticCursorStrategy;
+use hewn::view::{TerminalRenderer, View};
+use std::any::Any;
+
+#[derive(Debug)]
+struct Player {
+    coords: Coordinate,
+}
+
+impl Player {
+    fn new(x: usize, y: usize) -> Player {
+        Player {
+            coords: Coordinate { x, y },
+        }
+    }
+}
+
+impl GameObject for Player {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn collide(&mut self, _other: &dyn GameObject) {}
+
+    fn display(&self) -> String {
+        "@".to_owned()
+    }
+
+    fn get_collision_box(&self) -> CollisionBox {
+        CollisionBox {
+            x: self.coords.x..(self.coords.x + self.width()),
+            y: self.coords.y..(self.coords.y + 1),
+        }
+    }
+
+    fn get_coords(&self) -> &Coordinate {
+        &self.coords
+    }
+
+    fn next_step(&mut self) {}
+
+    fn priority(&self) -> u8 {
+        1
+    }
+
+    fn width(&self) -> usize {
+        1
+    }
+
+    fn is_player(&self) -> bool {
+        true
+    }
+}
+
+struct MinimalGame {
+    entities: Entities,
+    started: bool,
+}
+
+impl MinimalGame {
+    fn new() -> MinimalGame {
+        let mut entities = Entities::new();
+        let mut objects: Vec<Box<dyn GameObject>> = vec![Box::new(Player::new(5, 5))];
+        entities.add_game_objects(&mut objects);
+        MinimalGame {
+            entities,
+            started: true,
+        }
+    }
+
+    fn move_player(&mut self, key: Key) {
+        if let Some(player) = self
+            .entities
+            .game_objects
+            .iter_mut()
+            .find(|o| o.is_player())
+        {
+            if let Some(p) = player.as_mut_any().downcast_mut::<Player>() {
+                match key {
+                    Key::Left => {
+                        p.coords.x = p.coords.x.saturating_sub(1);
+                    }
+                    Key::Right => {
+                        p.coords.x = p.coords.x.saturating_add(1);
+                    }
+                    Key::Up => {
+                        p.coords.y = p.coords.y.saturating_add(1);
+                    }
+                    Key::Down => {
+                        p.coords.y = p.coords.y.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+impl GameLogic for MinimalGame {
+    fn start_game(&mut self) {
+        self.started = true;
+    }
+
+    fn next(&mut self, key: Option<Key>) {
+        if !self.started {
+            return;
+        }
+        if let Some(k) = key {
+            self.move_player(k);
+        }
+    }
+
+    fn entities(&self) -> &Entities {
+        &self.entities
+    }
+
+    fn debug_str(&self) -> Option<String> {
+        let player = self.entities.game_objects.iter().find(|o| o.is_player())?;
+        let c = player.get_coords();
+        Some(format!("Player @ ({}, {})", c.x, c.y))
+    }
+}
+
+fn main() {
+    let (stdout, stdin) = initialize_terminal_io();
+
+    let screen_height: u16 = 20;
+    let screen_width: u16 = 50;
+
+    let mut view = View {
+        view_cursor: Coordinate { x: 0, y: 0 },
+        renderer: Box::new(TerminalRenderer::new(stdout, screen_height, screen_width)),
+        cursor_strategy: Box::new(StaticCursorStrategy::new()),
+    };
+
+    let mut game = MinimalGame::new();
+    let mut runtime = TerminalRuntime::new(stdin, &mut game, &mut view);
+    runtime.start();
+}
+```
+
+## Examples
 
 ```bash
 # Terminal

--- a/examples/asciibird/src/game.rs
+++ b/examples/asciibird/src/game.rs
@@ -1,4 +1,4 @@
-use hewn::game::{BaseGame, Entities};
+use hewn::game::{Entities, GameLogic};
 use hewn::game_object::utils::{
     collision_pass, maybe_get_concrete_type, maybe_get_concrete_type_mut, take_game_object,
 };
@@ -92,7 +92,7 @@ impl Game {
     }
 }
 
-impl BaseGame for Game {
+impl GameLogic for Game {
     fn start_game(&mut self) {
         self.score = 0;
         self.get_mut_player_object().unwrap().reset();

--- a/examples/asciibird/src/game_objects/player_character.rs
+++ b/examples/asciibird/src/game_objects/player_character.rs
@@ -1,6 +1,6 @@
 use hewn::{
-    display::build_string,
     game_object::{CollisionBox, Coordinate, GameObject},
+    view::build_string,
 };
 use std::any::Any;
 

--- a/examples/asciibird/src/game_objects/wall.rs
+++ b/examples/asciibird/src/game_objects/wall.rs
@@ -1,6 +1,6 @@
 use hewn::{
-    display::build_string,
     game_object::{CollisionBox, Coordinate, GameObject},
+    view::build_string,
 };
 use rand::Rng;
 use std::any::Any;

--- a/examples/asciibird/src/lib.rs
+++ b/examples/asciibird/src/lib.rs
@@ -10,10 +10,10 @@ pub fn new_game_api() -> WasmGameApi {
     let asciibird_pointer = Box::new(game);
     let web_runtime = hewn::runtime::WebRuntime::new(
         asciibird_pointer,
-        hewn::display::BaseDisplay {
-            renderer: Box::new(hewn::display::WebRenderer::new(SCREEN_HEIGHT, SCREEN_WIDTH)),
+        hewn::view::View {
+            renderer: Box::new(hewn::view::WebRenderer::new(SCREEN_HEIGHT, SCREEN_WIDTH)),
             view_cursor: hewn::game_object::Coordinate { x: 0, y: 0 },
-            cursor_strategy: Box::new(hewn::display::cursor::FollowPlayerXCursorStrategy::new()),
+            cursor_strategy: Box::new(hewn::view::cursor::FollowPlayerXCursorStrategy::new()),
         },
     );
     hewn::runtime::new_wasm_game_api(web_runtime)

--- a/examples/asciibird/src/main.rs
+++ b/examples/asciibird/src/main.rs
@@ -2,11 +2,11 @@ mod game;
 mod game_objects;
 
 use asciibird::game::{SCREEN_HEIGHT, SCREEN_WIDTH};
-use hewn::display::cursor;
+use hewn::view::cursor;
 use hewn::game_object::Coordinate;
 #[cfg(not(target_arch = "wasm32"))]
 use hewn::{
-    display::{BaseDisplay, TerminalRenderer},
+    view::{View, TerminalRenderer},
     runtime::{initialize_terminal_io, TerminalRuntime},
 };
 
@@ -22,7 +22,7 @@ fn play_asciibird_in_terminal() {
 
     let mut game = default_game();
     let renderer = TerminalRenderer::new(stdout, SCREEN_HEIGHT, SCREEN_WIDTH);
-    let mut display = BaseDisplay {
+    let mut display = View {
         renderer: Box::new(renderer),
         view_cursor: Coordinate { x: 0, y: 0 },
         cursor_strategy: Box::new(cursor::FollowPlayerXCursorStrategy::new()),

--- a/examples/asciibird/src/main.rs
+++ b/examples/asciibird/src/main.rs
@@ -2,11 +2,12 @@ mod game;
 mod game_objects;
 
 use asciibird::game::{SCREEN_HEIGHT, SCREEN_WIDTH};
-use hewn::cursor;
+use hewn::display::cursor;
 use hewn::game_object::Coordinate;
 #[cfg(not(target_arch = "wasm32"))]
 use hewn::{
-    display::BaseDisplay, initialize_terminal_io, runtime::TerminalRuntime, TerminalRenderer,
+    display::{BaseDisplay, TerminalRenderer},
+    runtime::{initialize_terminal_io, TerminalRuntime},
 };
 
 fn main() {

--- a/examples/asciijump/src/game.rs
+++ b/examples/asciijump/src/game.rs
@@ -1,7 +1,7 @@
 use super::game_objects::platform::Platform;
 use super::game_objects::player_character::PlayerCharacter;
 use hewn::{
-    game::{BaseGame, Entities},
+    game::{Entities, GameLogic},
     game_object::{
         utils::{collision_pass, maybe_get_concrete_type, maybe_get_concrete_type_mut},
         GameObject,
@@ -111,7 +111,7 @@ impl Game {
     }
 }
 
-impl BaseGame for Game {
+impl GameLogic for Game {
     fn entities(&self) -> &Entities {
         &self.entities
     }
@@ -199,7 +199,7 @@ pub fn take_player_object(game_objects: &[Box<dyn GameObject>]) -> Option<&Playe
 #[cfg(test)]
 mod test {
     use crate::game_objects::{platform::Platform, player_character::PlayerCharacter};
-    use hewn::{game::BaseGame, game_object::GameObject};
+    use hewn::{game::GameLogic, game_object::GameObject};
 
     use super::Game;
     #[test]

--- a/examples/asciijump/src/game_objects/platform.rs
+++ b/examples/asciijump/src/game_objects/platform.rs
@@ -1,5 +1,5 @@
 use hewn::{
-    display::build_string,
+    view::build_string,
     game_object::{CollisionBox, Coordinate, GameObject},
 };
 use rand::Rng;

--- a/examples/asciijump/src/game_objects/player_character.rs
+++ b/examples/asciijump/src/game_objects/player_character.rs
@@ -1,5 +1,5 @@
 use hewn::{
-    display::build_string,
+    view::build_string,
     game_object::{CollisionBox, Coordinate, GameObject},
 };
 use std::any::Any;

--- a/examples/asciijump/src/lib.rs
+++ b/examples/asciijump/src/lib.rs
@@ -10,10 +10,10 @@ pub fn new_game_api() -> WasmGameApi {
     let asciijump_pointer = Box::new(game);
     let web_runtime = hewn::runtime::WebRuntime::new(
         asciijump_pointer,
-        hewn::display::BaseDisplay {
-            renderer: Box::new(hewn::display::WebRenderer::new(SCREEN_HEIGHT, SCREEN_WIDTH)),
+        hewn::view::View {
+            renderer: Box::new(hewn::view::WebRenderer::new(SCREEN_HEIGHT, SCREEN_WIDTH)),
             view_cursor: hewn::game_object::Coordinate { x: 0, y: 0 },
-            cursor_strategy: Box::new(hewn::display::cursor::FollowPlayerYCursorStrategy::new()),
+            cursor_strategy: Box::new(hewn::view::cursor::FollowPlayerYCursorStrategy::new()),
         },
     );
     hewn::runtime::new_wasm_game_api(web_runtime)

--- a/examples/asciijump/src/main.rs
+++ b/examples/asciijump/src/main.rs
@@ -1,8 +1,11 @@
 use asciijump::game::{SCREEN_HEIGHT, SCREEN_WIDTH};
-use hewn::cursor;
-use hewn::{game_object::Coordinate, BaseDisplay};
+use hewn::display::cursor;
+use hewn::game_object::Coordinate;
 #[cfg(not(target_arch = "wasm32"))]
-use hewn::{initialize_terminal_io, runtime::TerminalRuntime, TerminalRenderer};
+use hewn::{
+    display::{BaseDisplay, TerminalRenderer},
+    runtime::{initialize_terminal_io, TerminalRuntime},
+};
 
 use crate::game::default_game;
 

--- a/examples/asciijump/src/main.rs
+++ b/examples/asciijump/src/main.rs
@@ -1,9 +1,9 @@
 use asciijump::game::{SCREEN_HEIGHT, SCREEN_WIDTH};
-use hewn::display::cursor;
+use hewn::view::cursor;
 use hewn::game_object::Coordinate;
 #[cfg(not(target_arch = "wasm32"))]
 use hewn::{
-    display::{BaseDisplay, TerminalRenderer},
+    view::{View, TerminalRenderer},
     runtime::{initialize_terminal_io, TerminalRuntime},
 };
 
@@ -23,7 +23,7 @@ pub fn play_asciijump_in_terminal() {
     // TODO where we input height and width as args, can we make it a struct so labelled instead of just
     // guessing?
     let renderer = TerminalRenderer::new(stdout, SCREEN_HEIGHT, SCREEN_WIDTH);
-    let mut display = BaseDisplay {
+    let mut display = View {
         renderer: Box::new(renderer),
         view_cursor: Coordinate { x: 0, y: 0 },
         cursor_strategy: Box::new(cursor::FollowPlayerYCursorStrategy::new()),

--- a/examples/snake/src/game.rs
+++ b/examples/snake/src/game.rs
@@ -395,12 +395,11 @@ pub mod snake {
     use super::game_objects::player_character::{Direction, PlayerCharacter};
     use super::game_objects::wall::Wall;
     use hewn::game::{BaseGame, Entities};
-    use hewn::Key;
-
     use hewn::game_object::utils::{
         collision_pass, maybe_get_concrete_type, maybe_get_concrete_type_mut, take_game_object,
     };
     use hewn::game_object::{Coordinate, GameObject};
+    use hewn::runtime::Key;
     use rand::Rng;
 
     #[derive(Debug, PartialEq, Eq)]
@@ -414,10 +413,9 @@ pub mod snake {
     pub struct Game {
         pub width: usize,
         pub height: usize,
-
-        state: GameState,
         pub score: usize,
 
+        state: GameState,
         entities: Entities,
     }
 

--- a/examples/snake/src/game.rs
+++ b/examples/snake/src/game.rs
@@ -14,11 +14,11 @@ pub fn default_game() -> snake::Game {
 
 pub mod game_objects {
     pub mod player_character {
-        use hewn::display::build_string;
         use hewn::game_object::utils::maybe_get_concrete_type;
         use hewn::game_object::{
             GameObject, {CollisionBox, Coordinate},
         };
+        use hewn::view::build_string;
         use std::any::Any;
 
         use super::{food::Food, snake_body::SnakeBody, wall::Wall};
@@ -155,8 +155,8 @@ pub mod game_objects {
     pub mod food {
 
         use hewn::{
-            display::build_string,
             game_object::{CollisionBox, Coordinate, GameObject},
+            view::build_string,
         };
         use std::any::Any;
 
@@ -251,8 +251,8 @@ pub mod game_objects {
         use std::any::Any;
 
         use hewn::{
-            display::build_string,
             game_object::{CollisionBox, Coordinate, GameObject},
+            view::build_string,
         };
 
         #[derive(Debug)]
@@ -308,8 +308,8 @@ pub mod game_objects {
 
     pub mod wall {
         use hewn::{
-            display::build_string,
             game_object::{CollisionBox, Coordinate, GameObject},
+            view::build_string,
         };
         use std::any::Any;
 
@@ -394,7 +394,7 @@ pub mod snake {
     use super::game_objects::food::Food;
     use super::game_objects::player_character::{Direction, PlayerCharacter};
     use super::game_objects::wall::Wall;
-    use hewn::game::{BaseGame, Entities};
+    use hewn::game::{Entities, GameLogic};
     use hewn::game_object::utils::{
         collision_pass, maybe_get_concrete_type, maybe_get_concrete_type_mut, take_game_object,
     };
@@ -528,7 +528,7 @@ pub mod snake {
         }
     }
 
-    impl BaseGame for Game {
+    impl GameLogic for Game {
         // duplication across games - consider options to refactor out?
         fn start_game(&mut self) {
             self.score = 0;
@@ -593,7 +593,7 @@ pub mod snake {
 #[cfg(test)]
 mod test {
     use hewn::{
-        game::BaseGame,
+        game::GameLogic,
         game_object::utils::{detect_collision, take_game_object},
     };
 

--- a/examples/snake/src/lib.rs
+++ b/examples/snake/src/lib.rs
@@ -12,10 +12,11 @@ pub fn new_game_api() -> WasmGameApi {
     let snake_pointer = Box::new(game);
     let web_runtime = hewn::runtime::WebRuntime::new(
         snake_pointer,
-        hewn::display::BaseDisplay {
-            renderer: Box::new(hewn::display::WebRenderer::new(height, width)),
+        // should the game actually own the display and the runtime only handle the IO?
+        hewn::view::View {
+            renderer: Box::new(hewn::view::WebRenderer::new(height, width)),
             view_cursor: hewn::game_object::Coordinate { x: 0, y: 0 },
-            cursor_strategy: Box::new(hewn::display::cursor::StaticCursorStrategy::new()),
+            cursor_strategy: Box::new(hewn::view::cursor::StaticCursorStrategy::new()),
         },
     );
     hewn::runtime::new_wasm_game_api(web_runtime)

--- a/examples/snake/src/main.rs
+++ b/examples/snake/src/main.rs
@@ -1,10 +1,10 @@
 mod game;
 use crate::game::default_game;
+#[cfg(not(target_arch = "wasm32"))]
+use hewn::display::{BaseDisplay, TerminalRenderer};
 use hewn::game_object::Coordinate;
 #[cfg(not(target_arch = "wasm32"))]
-use hewn::{
-    display::BaseDisplay, initialize_terminal_io, runtime::TerminalRuntime, TerminalRenderer,
-};
+use hewn::runtime::{initialize_terminal_io, TerminalRuntime};
 
 const SCREEN_WIDTH: u16 = 30;
 const SCREEN_HEIGHT: u16 = 25;

--- a/examples/snake/src/main.rs
+++ b/examples/snake/src/main.rs
@@ -1,10 +1,10 @@
 mod game;
 use crate::game::default_game;
-#[cfg(not(target_arch = "wasm32"))]
-use hewn::display::{BaseDisplay, TerminalRenderer};
 use hewn::game_object::Coordinate;
 #[cfg(not(target_arch = "wasm32"))]
 use hewn::runtime::{initialize_terminal_io, TerminalRuntime};
+#[cfg(not(target_arch = "wasm32"))]
+use hewn::view::{TerminalRenderer, View};
 
 const SCREEN_WIDTH: u16 = 30;
 const SCREEN_HEIGHT: u16 = 25;
@@ -13,10 +13,10 @@ fn main() {
     let (stdout, stdin) = initialize_terminal_io();
     let mut game = default_game();
     let renderer = TerminalRenderer::new(stdout, SCREEN_HEIGHT, SCREEN_WIDTH);
-    let mut display = BaseDisplay {
+    let mut display = View {
         renderer: Box::new(renderer),
         view_cursor: Coordinate { x: 0, y: 0 },
-        cursor_strategy: Box::new(hewn::display::cursor::StaticCursorStrategy::new()),
+        cursor_strategy: Box::new(hewn::view::cursor::StaticCursorStrategy::new()),
     };
     let mut runtime = TerminalRuntime::new(stdin, &mut game, &mut display);
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,4 @@
-//! TODO: Add module documentation for engine
-//! Core game engine providing rendering, input handling, and game object management
-
-pub mod display;
 pub mod game;
 pub mod game_object;
 pub mod runtime;
+pub mod view;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,8 +5,3 @@ pub mod display;
 pub mod game;
 pub mod game_object;
 pub mod runtime;
-
-pub use self::display::*;
-pub use self::game_object::GameObject;
-#[cfg(not(target_arch = "wasm32"))]
-pub use self::runtime::initialize_terminal_io;

--- a/src/engine/display.rs
+++ b/src/engine/display.rs
@@ -67,7 +67,7 @@ impl BaseDisplay {
 }
 
 pub mod cursor {
-    use crate::engine::{game_object::Coordinate, GameObject, Renderer};
+    use crate::{display::Renderer, game_object::Coordinate, game_object::GameObject};
 
     pub trait CursorStrategy {
         fn update(

--- a/src/engine/game.rs
+++ b/src/engine/game.rs
@@ -1,7 +1,9 @@
+//! Game logic trait and entity handling.
+
 use crate::game_object::GameObject;
 use crate::runtime::Key;
 
-pub trait BaseGame {
+pub trait GameLogic {
     // Game logic
     fn start_game(&mut self);
     fn next(&mut self, key: Option<Key>);

--- a/src/engine/game.rs
+++ b/src/engine/game.rs
@@ -3,30 +3,38 @@
 use crate::game_object::GameObject;
 use crate::runtime::Key;
 
+/// Trait which all games must implement.
 pub trait GameLogic {
     // Game logic
+    /// Start the game.
     fn start_game(&mut self);
+    /// Compute the next game state based on player input.
     fn next(&mut self, key: Option<Key>);
 
     // Game state
+    /// Get the entities of the game.
     fn entities(&self) -> &Entities;
 
-    // render
+    // Debug rendering
+    /// Get a string for debugging.
     fn debug_str(&self) -> Option<String>;
 }
 
+/// A collection of game objects.
 #[derive(Debug)]
 pub struct Entities {
     pub game_objects: Vec<Box<dyn GameObject>>,
 }
 
 impl Entities {
+    /// Create a new collection of game objects.
     pub fn new() -> Entities {
         Entities {
             game_objects: vec![],
         }
     }
 
+    /// Add a collection of game objects to the entities.
     pub fn add_game_objects(&mut self, game_objects: &mut Vec<Box<dyn GameObject>>) {
         self.game_objects.append(game_objects);
 

--- a/src/engine/game_object.rs
+++ b/src/engine/game_object.rs
@@ -1,3 +1,5 @@
+//! Game object traits and utils.
+
 use std::{any::Any, fmt::Debug, ops::Range};
 
 pub trait GameObject: Debug + Any {

--- a/src/engine/game_object.rs
+++ b/src/engine/game_object.rs
@@ -2,6 +2,7 @@
 
 use std::{any::Any, fmt::Debug, ops::Range};
 
+/// Trait which all game objects must implement.
 pub trait GameObject: Debug + Any {
     fn as_any(&self) -> &dyn Any;
     fn as_mut_any(&mut self) -> &mut dyn Any;
@@ -15,18 +16,21 @@ pub trait GameObject: Debug + Any {
     fn is_player(&self) -> bool;
 }
 
+/// A coordinate in the game world.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Coordinate {
     pub x: usize,
     pub y: usize,
 }
 
+/// A collision box for a game object.
 #[derive(Debug)]
 pub struct CollisionBox {
     pub x: Range<usize>,
     pub y: Range<usize>,
 }
 
+/// Utility functions for game objects.
 pub mod utils {
     use crate::engine::game_object::GameObject;
     use std::{any::Any, ops::Range};

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -16,6 +16,7 @@ use wasm_bindgen::prelude::*;
 const FRAME_RATE_MILLIS: u64 = 10;
 const GAME_STEP_MILLIS: u64 = 100;
 
+/// Key for player control.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Key {
     Left,
@@ -26,6 +27,7 @@ pub enum Key {
     Escape,
 }
 
+/// Initialize terminal IO.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn initialize_terminal_io() -> (
     RawTerminal<Stdout>,
@@ -36,6 +38,7 @@ pub fn initialize_terminal_io() -> (
     (stdout, stdin)
 }
 
+/// A runtime for a terminal game.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct TerminalRuntime<'a> {
     pub stdin: termion::input::Keys<termion::AsyncReader>,
@@ -61,6 +64,7 @@ impl TerminalRuntime<'_> {
         }
     }
 
+    /// Start the game loop listening for player input and rendering the game.
     pub fn start(&mut self) {
         loop {
             let input = self.stdin.next();
@@ -96,6 +100,7 @@ impl TerminalRuntime<'_> {
     }
 }
 
+/// Map a termion key to a Hewn key.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn map_termion_key(key: termion::event::Key) -> Option<Key> {
     match key {
@@ -109,31 +114,36 @@ pub fn map_termion_key(key: termion::event::Key) -> Option<Key> {
     }
 }
 
+/// A runtime for a web game.
 pub struct WebRuntime {
     game: Box<dyn GameLogic>,
     display: View,
 }
 
 impl WebRuntime {
+    /// Create a new web runtime.
     pub fn new(game: Box<dyn GameLogic>, display: View) -> WebRuntime {
         WebRuntime { game, display }
     }
 
+    /// Start the game loop.
     pub fn start(&mut self) {
         self.game.start_game();
     }
 
-    // next_frame? and self.game.next_frame?
+    /// Compute the next game state based on player input.
     pub fn tick(&mut self, key: Option<WasmKey>) {
         self.game.next(map_wasm_key(key));
     }
 
+    /// Render the game to a string.
     pub fn render(&mut self) -> String {
         self.display
             .next(&self.game.entities().game_objects, self.game.debug_str())
     }
 }
 
+/// A web game API.
 #[wasm_bindgen]
 pub struct WasmGameApi {
     web_runtime: WebRuntime,
@@ -158,6 +168,8 @@ pub fn new_wasm_game_api(web_runtime: WebRuntime) -> WasmGameApi {
     WasmGameApi { web_runtime }
 }
 
+/// Map a web key to a Hewn key.
+/// TODO: do we need this, or should we just expose the Hewn key enum?
 fn map_wasm_key(k: Option<WasmKey>) -> Option<Key> {
     if k.is_none() {
         return None;

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -1,4 +1,6 @@
-use super::{display::BaseDisplay, game::BaseGame};
+//! Wasm and terminal game runtimes.
+
+use super::{game::GameLogic, view::View};
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::{self, Stdout};
 use std::{
@@ -37,8 +39,8 @@ pub fn initialize_terminal_io() -> (
 #[cfg(not(target_arch = "wasm32"))]
 pub struct TerminalRuntime<'a> {
     pub stdin: termion::input::Keys<termion::AsyncReader>,
-    pub game: &'a mut dyn BaseGame,
-    pub display: &'a mut BaseDisplay,
+    pub game: &'a mut dyn GameLogic,
+    pub display: &'a mut View,
     last_frame_time: Instant,
     player_control_key: Option<Key>,
 }
@@ -47,8 +49,8 @@ pub struct TerminalRuntime<'a> {
 impl TerminalRuntime<'_> {
     pub fn new<'a>(
         stdin: termion::input::Keys<termion::AsyncReader>,
-        game: &'a mut dyn BaseGame,
-        display: &'a mut BaseDisplay,
+        game: &'a mut dyn GameLogic,
+        display: &'a mut View,
     ) -> TerminalRuntime<'a> {
         TerminalRuntime {
             stdin,
@@ -108,12 +110,12 @@ pub fn map_termion_key(key: termion::event::Key) -> Option<Key> {
 }
 
 pub struct WebRuntime {
-    game: Box<dyn BaseGame>,
-    display: BaseDisplay,
+    game: Box<dyn GameLogic>,
+    display: View,
 }
 
 impl WebRuntime {
-    pub fn new(game: Box<dyn BaseGame>, display: BaseDisplay) -> WebRuntime {
+    pub fn new(game: Box<dyn GameLogic>, display: View) -> WebRuntime {
         WebRuntime { game, display }
     }
 
@@ -121,6 +123,7 @@ impl WebRuntime {
         self.game.start_game();
     }
 
+    // next_frame? and self.game.next_frame?
     pub fn tick(&mut self, key: Option<WasmKey>) {
         self.game.next(map_wasm_key(key));
     }

--- a/src/engine/view.rs
+++ b/src/engine/view.rs
@@ -11,6 +11,7 @@ use std::{
 #[cfg(not(target_arch = "wasm32"))]
 use termion::raw::RawTerminal;
 
+/// A view of the game world.
 pub struct View {
     pub view_cursor: Coordinate,
     pub renderer: Box<dyn Renderer>,
@@ -67,6 +68,7 @@ impl View {
     }
 }
 
+/// Player view cursor and strategies.
 pub mod cursor {
     use crate::{game_object::Coordinate, game_object::GameObject, view::Renderer};
 
@@ -145,6 +147,8 @@ pub mod cursor {
         }
     }
 }
+
+/// Trait which all renderers must implement.
 pub trait Renderer {
     fn screen_height(&self) -> u16;
     fn screen_width(&self) -> u16;
@@ -152,6 +156,7 @@ pub trait Renderer {
     fn render(&mut self, debug_string: Option<String>, view: String, h: u16) -> String;
 }
 
+/// A renderer for the terminal.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct TerminalRenderer {
     stdout: RawTerminal<Stdout>,
@@ -215,6 +220,7 @@ impl Renderer for TerminalRenderer {
     }
 }
 
+/// A renderer for the web.
 pub struct WebRenderer {
     screen_height: u16,
     screen_width: u16,
@@ -257,6 +263,7 @@ impl Renderer for WebRenderer {
     }
 }
 
+/// Utility function to build a string of a given character and length.
 pub fn build_string(ch: char, length: usize) -> String {
     ch.to_string().repeat(length)
 }

--- a/src/engine/view.rs
+++ b/src/engine/view.rs
@@ -1,14 +1,9 @@
-use crate::engine::display::cursor::CursorStrategy;
-use crate::engine::game_object::utils;
+//! View, cursor and renderer.
 
 use super::game_object::Coordinate;
 use super::game_object::GameObject;
-
-pub struct BaseDisplay {
-    pub view_cursor: Coordinate,
-    pub renderer: Box<dyn Renderer>,
-    pub cursor_strategy: Box<dyn CursorStrategy>,
-}
+use crate::engine::game_object::utils;
+use crate::engine::view::cursor::CursorStrategy;
 use std::{
     io::{Stdout, Write},
     iter::zip,
@@ -16,7 +11,13 @@ use std::{
 #[cfg(not(target_arch = "wasm32"))]
 use termion::raw::RawTerminal;
 
-impl BaseDisplay {
+pub struct View {
+    pub view_cursor: Coordinate,
+    pub renderer: Box<dyn Renderer>,
+    pub cursor_strategy: Box<dyn CursorStrategy>,
+}
+
+impl View {
     pub fn next(
         &mut self,
         game_objects: &[Box<dyn GameObject>],
@@ -67,7 +68,7 @@ impl BaseDisplay {
 }
 
 pub mod cursor {
-    use crate::{display::Renderer, game_object::Coordinate, game_object::GameObject};
+    use crate::{game_object::Coordinate, game_object::GameObject, view::Renderer};
 
     pub trait CursorStrategy {
         fn update(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! Hewn aims to be a simple and flexible game engine, with a focus on readability and
 //! maintainability.
 //!
-//! For more information, see the [README](https://github.com/joshuamason/hewn).
+//! For more information, see the [README](https://github.com/joshua-mason/hewn).
 
 mod engine;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,15 +24,7 @@
 
 mod engine;
 
-pub use engine::cursor;
 pub use engine::display;
 pub use engine::game;
 pub use engine::game_object;
 pub use engine::runtime;
-pub use engine::runtime::Key;
-
-#[cfg(not(target_arch = "wasm32"))]
-pub use engine::initialize_terminal_io;
-pub use engine::BaseDisplay;
-#[cfg(not(target_arch = "wasm32"))]
-pub use engine::TerminalRenderer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,17 @@
 //! # Hewn
 //!
-//! **Status:** Alpha – This is an experimental crate for educational purposes.
+//! **Status:** Alpha – experimental crate for educational purposes.
 //!
-//! Hewn is a crate for making games in the terminal and exporting as WebAssembly.
+//! Hewn is a crate for making games, with support for terminal and web runtimes.
 //!
-//! Hewn was created as an abstraction from an original terminal game, `asciijump`, in order
-//! to explore how a basic game engine might work in a low level language.
+//! Hewn aims to be a simple and flexible game engine, with a focus on readability and
+//! maintainability.
 //!
-//! <!--
-//! # Getting started
-//!
-//! We represent a game in this library with these core concepts:
-//!
-//! * the trait `BaseGame` represents the central controller for game logic, on the game loop, where we can access the game objects
-//! * the trait `GameObject` represents the items in a game, for example players, walls, platforms.
-//! * The Controller (`WebController` or `TerminalController`) orchestrate the `BaseGame` with user IO. These are have different implementations depending on the type of game. We support terminal and web based games (via wasm).
-//! * The CursorStrategy which controls the player's view of the game. There are a few out-of-the-box strategies implemented in the library (`FollowPlayerYCursorStrategy`, `FollowPlayerXCursorStrategy` and `StaticCursorStrategy`)
-//!
-//! ## Game Objects
-//!
-//!
-//! -->
+//! For more information, see the [README](https://github.com/joshuamason/hewn).
 
 mod engine;
 
-pub use engine::display;
 pub use engine::game;
 pub use engine::game_object;
 pub use engine::runtime;
+pub use engine::view;


### PR DESCRIPTION
Refactor terms to more accurate descriptions - for example, we manage the view rather than display with the renderer and cursor. We also rename `BaseGame` to `GameLogic` to better communicate the use of this trait. 

We also update documentation with an example and refresh the rust docs for the project.