### PR TITLE
feat(wgpu): colour selection in `RenderComponent`, add `CameraStrategy`, fix panic on unknown `Key` bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hewn"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 name = "asciibird"
 version = "0.0.0"
 dependencies = [
+ "cgmath",
  "getrandom 0.2.15",
  "hewn",
  "js-sys",
@@ -131,6 +132,7 @@ dependencies = [
 name = "asciijump"
 version = "0.0.0"
 dependencies = [
+ "cgmath",
  "getrandom 0.2.15",
  "hewn",
  "js-sys",
@@ -1916,6 +1918,7 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 name = "tutorial"
 version = "0.1.0"
 dependencies = [
+ "cgmath",
  "hewn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,7 @@ dependencies = [
 name = "snake"
 version = "0.0.0"
 dependencies = [
+ "cgmath",
  "getrandom 0.2.15",
  "hewn",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A simple game engine built for educational purposes."
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/joshua-mason/hewn"
-keywords = ["game", "engine", "wasm", "terminal"]
+keywords = ["game engine", "wgpu", "terminal", "ecs", "snake"]
 categories = ["game-engines"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hewn"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 description = "A simple game engine built for educational purposes."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hewn is a minimal Rust game engine for learning and tinkering, with support for 
 - 🎮 **ECS** - Entity Component System architecture
 - ⚡ **Cross-Platform** - Write once, run anywhere
 
-## Quick Start
+## Getting started
 
 > [!NOTE]
 > **Complete tutorial code** is available in `examples/tutorial/`. The following tutorial builds up from the simplest possible game.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ impl HelloGame {
         
         let player_id = ecs.add_entity_from_components(Components {
             position: Some(PositionComponent { x: 5, y: 5 }), // 2.
-            render: Some(RenderComponent { ascii_character: '@' }), // 3.
+            render: Some(RenderComponent { // 3.
+                ascii_character: '@',
+                rgb: cgmath::Vector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            }),
             velocity: None,
             size: Some(SizeComponent { x: 1, y: 1 }), // 4.
             camera_follow: None,
@@ -123,7 +130,7 @@ impl HelloGame {
 
 1. Added `player_id` field to store a reference to our character entity
 2. Player positioned at coordinates (5, 5) in the game world  
-3. `RenderComponent` makes the entity appear as `@` character on screen
+3. `RenderComponent` makes the entity appear as `@` character on screen - we also include an `rgb` with the colour for wgpu rendering.
 4. `SizeComponent` defines the entity's collision box (1×1 unit)
 
 Next, let's update the game loop and debug display:
@@ -215,7 +222,14 @@ impl HelloGame {
         
         let player_id = ecs.add_entity_from_components(Components {
             position: Some(PositionComponent { x: 5, y: 5 }), 
-            render: Some(RenderComponent { ascii_character: '@' }),
+            render: Some(RenderComponent { 
+                ascii_character: '@',
+                rgb: cgmath::Vector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            }),
             velocity: Some(VelocityComponent { x: 0, y: 0 }), // 2.
             size: Some(SizeComponent { x: 2, y: 1 }), // 3.
             camera_follow: None,
@@ -311,7 +325,14 @@ impl HelloGame {
         // Add a wall
         ecs.add_entity_from_components(Components {
             position: Some(PositionComponent { x: 8, y: 5 }), // 1.
-            render: Some(RenderComponent { ascii_character: '#' }), // 2.
+            render: Some(RenderComponent { // 2.
+                ascii_character: '#'
+                rgb: cgmath::Vector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            }),
             velocity: None, // 3.
             size: Some(SizeComponent { x: 2, y: 1 }), // 4.
             camera_follow: None,
@@ -323,7 +344,7 @@ impl HelloGame {
 ```
 
 1. Wall positioned at (8, 5) - to the right of the player starting position
-2. Wall renders as `#` character on screen
+2. Wall renders as `#` character on screen, or a black square in wgpu rendering
 3. Wall has no velocity (it doesn't move) - note that this could also be set to `VelocityComponent { x: 0, y: 0 }`.
 4. Wall has 2×1 size, so it appears as `##` (2 units wide)
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ impl GameHandler for HelloGame {
 ```
 
 1. `collision_pass()` returns pairs of entities that are colliding
-2. **Important**: Iterate over collision pairs `[a, b]` - don't use `.flatten()` which loses pairing info
+2. Iterate over collision pairs `[a, b]`
 3. When collision detected, immediately stop the player by resetting velocity to `(0, 0)`
 4. **Critical**: Call `ecs.step()` AFTER collision detection to apply the movement
 

--- a/README.md
+++ b/README.md
@@ -287,28 +287,7 @@ impl GameHandler for HelloGame {
 
 Your `@` character now responds to arrow keys! Try moving around and watch the debug text update with your position. Now let's see the same game running in a desktop window...
 
-### Step 4: Same Game, Desktop Window
-
-Now we've built our game, it's possible to run in our `WindowRuntime`. Without changing our game, we use the `wgpu` runtime:
-
-```rust
-// ..
-use hewn::wgpu::runtime::WindowRuntime; // NEW!
-
-// ..
-
-fn main() {
-    let mut game = HelloGame::new(); // Same game!
-    let mut runtime = WindowRuntime::new(); // 1.
-    let _ = runtime.start(&mut game);
-}
-```
-
-1. Swap `TerminalRuntime` for `WindowRuntime` - that's literally it!
-
-Your `@` character now renders as a colored square in a desktop window.
-
-### Step 5: Add Collision Detection
+### Step 4: Add Collision Detection
 
 Let's add a wall that blocks the player's movement to make it feel like a real game.
 
@@ -388,6 +367,28 @@ impl GameHandler for HelloGame {
 Now you'll see a `##` wall that blocks your `@` character's movement! Try moving right into it.
 
 🎉 Congratulations! You’ve built a simple game with movement and collision using Hewn. Explore, experiment, and have fun making your own games! Check the examples or docs for more advanced features.
+
+
+### Step 5: Same Game, Desktop Window
+
+Now we've built our game, it's possible to run in our `WindowRuntime`. Without changing our game, we use the `wgpu` runtime:
+
+```rust
+// ..
+use hewn::wgpu::runtime::WindowRuntime; // NEW!
+
+// ..
+
+fn main() {
+    let mut game = HelloGame::new(); // Same game!
+    let mut runtime = WindowRuntime::new(); // 1.
+    let _ = runtime.start(&mut game);
+}
+```
+
+1. Swap `TerminalRuntime` for `WindowRuntime` - that's literally it!
+
+Your `@` character now renders as a colored square in a desktop window.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ pub struct GameController { // 1.
 }
 
 impl GameController {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             is_up_pressed: false,
             is_down_pressed: false,
@@ -190,7 +190,7 @@ impl GameController {
         }
     }
 
-    pub(crate) fn handle_key(&mut self, key: Key, is_pressed: bool) -> bool {
+    pub fn handle_key(&mut self, key: Key, is_pressed: bool) -> bool {
         match key { // 2.
             Key::Up => { self.is_up_pressed = is_pressed; true }
             Key::Down => { self.is_down_pressed = is_pressed; true }

--- a/examples/asciibird/Cargo.toml
+++ b/examples/asciibird/Cargo.toml
@@ -7,6 +7,7 @@ hewn = { path = "../../" }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 rand = "0.8"
+cgmath = "0.18.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/examples/asciibird/src/game.rs
+++ b/examples/asciibird/src/game.rs
@@ -26,10 +26,10 @@ pub enum GameState {
 pub struct Game {
     pub state: GameState,
     pub score: u16,
+    pub player_id: EntityId,
 
     rng: Box<dyn rand::RngCore>,
     ecs: ECS,
-    player_id: EntityId,
     wall_ids: HashSet<EntityId>,
     width: u16,
     height: u16,
@@ -72,6 +72,7 @@ impl Game {
             size: Some(SizeComponent { x: 1, y: 1 }),
             render: Some(RenderComponent {
                 ascii_character: '#',
+                rgb: (0.0, 0.0, 0.0).into(),
             }),
             camera_follow: Some(CameraFollow {}),
         };
@@ -87,6 +88,7 @@ impl Game {
                 size: Some(SizeComponent { x: 1, y: 1 }),
                 render: Some(RenderComponent {
                     ascii_character: '\\',
+                    rgb: (0.0, 0.0, 0.5).into(),
                 }),
                 camera_follow: None,
             };

--- a/examples/asciibird/src/main.rs
+++ b/examples/asciibird/src/main.rs
@@ -23,6 +23,10 @@ fn play_asciibird_in_terminal() {
 
 fn play_asciibird_in_wgpu() {
     let mut game = create_game(None);
+    let player_entity_id = game.player_id;
     let mut runtime = wgpu::runtime::WindowRuntime::new();
-    let _ = runtime.start(&mut game);
+    let _ = runtime.start(
+        &mut game,
+        wgpu::render::CameraStrategy::CameraFollow(player_entity_id),
+    );
 }

--- a/examples/asciijump/Cargo.toml
+++ b/examples/asciijump/Cargo.toml
@@ -7,6 +7,7 @@ hewn = { path = "../../" }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 rand = "0.8"
+cgmath = "0.18.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/examples/asciijump/src/game.rs
+++ b/examples/asciijump/src/game.rs
@@ -1,3 +1,4 @@
+use cgmath::Vector3;
 use hewn::ecs::{
     CameraFollow, EntityId, PositionComponent, RenderComponent, SizeComponent, VelocityComponent,
 };
@@ -32,10 +33,10 @@ pub struct Game {
     pub height: u16,
     pub state: GameState,
     pub score: u16,
+    pub player_id: EntityId,
 
     rng: Box<dyn RngCore>,
     ecs: ECS,
-    player_id: EntityId,
     platform_ids: HashSet<EntityId>,
 }
 
@@ -93,6 +94,7 @@ impl Game {
             size: Some(SizeComponent { x: 1, y: 1 }),
             render: Some(RenderComponent {
                 ascii_character: '#',
+                rgb: (0.0, 0.0, 0.0).into(),
             }),
             camera_follow: Some(CameraFollow {}),
         };
@@ -108,6 +110,7 @@ impl Game {
                 size: Some(SizeComponent { x: 3, y: 1 }),
                 render: Some(RenderComponent {
                     ascii_character: '=',
+                    rgb: (0.0, 0.0, 0.5).into(),
                 }),
                 camera_follow: None,
             };

--- a/examples/asciijump/src/game.rs
+++ b/examples/asciijump/src/game.rs
@@ -268,7 +268,7 @@ mod tests {
 
     fn get_player_entity<'a>(game: &'a Game) -> &'a hewn::ecs::Entity {
         let ecs = game.ecs();
-        let mut tracked = ecs.get_entities_by(ComponentType::CameraFollow);
+        let mut tracked = ecs.get_entities_with_component(ComponentType::CameraFollow);
         assert!(tracked.len() > 0, "player entity not found");
         tracked.remove(0)
     }

--- a/examples/asciijump/src/main.rs
+++ b/examples/asciijump/src/main.rs
@@ -23,5 +23,9 @@ pub fn play_asciijump_in_terminal() {
 pub fn play_asciijump_in_wgpu() {
     let mut game = create_game(None);
     let mut runtime = wgpu::runtime::WindowRuntime::new();
-    let _ = runtime.start(&mut game);
+    let player_entity_id = game.player_id;
+    let _ = runtime.start(
+        &mut game,
+        wgpu::render::CameraStrategy::CameraFollow(player_entity_id),
+    );
 }

--- a/examples/snake/Cargo.toml
+++ b/examples/snake/Cargo.toml
@@ -8,6 +8,7 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 rand = "0.8"
 winit = "0.30.12"
+cgmath = "0.18.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/examples/snake/index.html
+++ b/examples/snake/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn WGPU</title>
+    <title>Hewn Snake</title>
     <style>
         canvas {
             width: 800px;

--- a/examples/snake/src/game.rs
+++ b/examples/snake/src/game.rs
@@ -1,3 +1,4 @@
+use cgmath;
 use hewn::ecs::{
     CameraFollow, EntityId, PositionComponent, RenderComponent, SizeComponent, VelocityComponent,
 };
@@ -99,6 +100,11 @@ impl Game {
             size: Some(SizeComponent { x: 1, y: 1 }),
             render: Some(RenderComponent {
                 ascii_character: '0',
+                rgb: cgmath::Vector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
             }),
             camera_follow: Some(CameraFollow {}),
         };
@@ -115,6 +121,11 @@ impl Game {
                 size: Some(SizeComponent { x: 1, y: 1 }),
                 render: Some(RenderComponent {
                     ascii_character: '#',
+                    rgb: cgmath::Vector3 {
+                        x: 0.0,
+                        y: 0.1,
+                        z: 0.0,
+                    },
                 }),
                 camera_follow: None,
             };
@@ -164,6 +175,11 @@ impl Game {
             size: Some(SizeComponent { x: 1, y: 1 }),
             render: Some(RenderComponent {
                 ascii_character: '+',
+                rgb: cgmath::Vector3 {
+                    x: 0.1,
+                    y: 0.0,
+                    z: 0.0,
+                },
             }),
             camera_follow: None,
         };
@@ -230,6 +246,11 @@ impl Game {
             size: Some(SizeComponent { x: 1, y: 1 }),
             render: Some(RenderComponent {
                 ascii_character: 'o',
+                rgb: cgmath::Vector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.1,
+                },
             }),
             camera_follow: None,
         };

--- a/examples/snake/src/game.rs
+++ b/examples/snake/src/game.rs
@@ -378,7 +378,7 @@ fn generate_walls_positions(width: u16, height: u16) -> Vec<(u16, u16)> {
         walls.push((x_index, 1));
         walls.push((x_index, height));
     }
-    for y_index in 0..height {
+    for y_index in 1..(height) {
         walls.push((0, y_index));
         walls.push((width - 1, y_index));
     }

--- a/examples/snake/src/lib.rs
+++ b/examples/snake/src/lib.rs
@@ -9,5 +9,5 @@ pub fn run_in_canvas(width: u16, height: u16, seed: Option<u64>) {
     let mut game = create_game(width, height, seed);
     game.start_game();
     let mut runtime = hewn::wgpu::runtime::WindowRuntime::new();
-    let _ = runtime.start(&mut game);
+    let _ = runtime.start(&mut game, hewn::wgpu::render::CameraStrategy::AllEntities);
 }

--- a/examples/snake/src/main.rs
+++ b/examples/snake/src/main.rs
@@ -10,5 +10,5 @@ fn main() {
     let mut game = create_game(SCREEN_WIDTH, SCREEN_HEIGHT, None);
     game.start_game();
     let mut runtime = hewn::wgpu::runtime::WindowRuntime::new();
-    let _ = runtime.start(&mut game);
+    let _ = runtime.start(&mut game, hewn::wgpu::render::CameraStrategy::AllEntities);
 }

--- a/examples/snake/src/main.rs
+++ b/examples/snake/src/main.rs
@@ -11,8 +11,4 @@ fn main() {
     game.start_game();
     let mut runtime = hewn::wgpu::runtime::WindowRuntime::new();
     let _ = runtime.start(&mut game);
-
-    let mut game = create_game(SCREEN_WIDTH, SCREEN_HEIGHT, None);
-    let mut runtime = hewn::terminal::runtime::TerminalRuntime::new(SCREEN_WIDTH, SCREEN_HEIGHT);
-    runtime.start(&mut game);
 }

--- a/examples/tutorial/Cargo.toml
+++ b/examples/tutorial/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+cgmath = "0.18.0"
 hewn = { path = "../../" }

--- a/examples/tutorial/src/main.rs
+++ b/examples/tutorial/src/main.rs
@@ -1,3 +1,4 @@
+use cgmath;
 use hewn::ecs::{Components, EntityId, PositionComponent, RenderComponent, SizeComponent};
 use hewn::wgpu::runtime::WindowRuntime;
 use hewn::{ecs::ECS, runtime::GameHandler};
@@ -56,6 +57,11 @@ impl HelloGame {
             position: Some(PositionComponent { x: 5, y: 5 }),
             render: Some(RenderComponent {
                 ascii_character: '@',
+                rgb: cgmath::Vector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
             }),
             velocity: Some(VelocityComponent { x: 0, y: 0 }),
             size: Some(SizeComponent { x: 1, y: 1 }),
@@ -65,6 +71,11 @@ impl HelloGame {
             position: Some(PositionComponent { x: 8, y: 5 }),
             render: Some(RenderComponent {
                 ascii_character: '#',
+                rgb: cgmath::Vector3 {
+                    x: 0.0,
+                    y: 0.5,
+                    z: 0.0,
+                },
             }),
             velocity: None,
             size: Some(SizeComponent { x: 2, y: 1 }),
@@ -142,5 +153,9 @@ impl GameHandler for HelloGame {
 fn main() {
     let mut game = HelloGame::new();
     let mut runtime = WindowRuntime::new();
-    let _ = runtime.start(&mut game);
+    let entity_id = game.player_id;
+    let _ = runtime.start(
+        &mut game,
+        hewn::wgpu::render::CameraStrategy::CameraFollow(entity_id),
+    );
 }

--- a/src/engine/ecs.rs
+++ b/src/engine/ecs.rs
@@ -77,6 +77,7 @@ pub struct PositionComponent {
     pub x: u16,
     pub y: u16,
 }
+
 impl Component for PositionComponent {
     const TYPE: ComponentType = ComponentType::Position;
 }
@@ -183,7 +184,7 @@ impl ECS {
         self.entities.iter_mut().find(|e| e.id == id)
     }
 
-    pub fn get_entities_by(&self, component_type: ComponentType) -> Vec<&Entity> {
+    pub fn get_entities_with_component(&self, component_type: ComponentType) -> Vec<&Entity> {
         let entities = self
             .entities
             .iter()

--- a/src/engine/ecs.rs
+++ b/src/engine/ecs.rs
@@ -1,3 +1,5 @@
+use cgmath::Vector3;
+
 #[derive(Debug, Clone, Copy)]
 pub struct Entity {
     pub id: EntityId,
@@ -53,7 +55,10 @@ impl Entity {
                     x: size.0,
                     y: size.1,
                 }),
-                render: ascii_character.map(|c| RenderComponent { ascii_character: c }),
+                render: ascii_character.map(|c| RenderComponent {
+                    ascii_character: c,
+                    rgb: Vector3::new(0.0, 0.0, 0.0),
+                }),
                 camera_follow: if track { Some(CameraFollow {}) } else { None },
             },
         }
@@ -103,6 +108,7 @@ impl Component for SizeComponent {
 #[derive(Debug, Clone, Copy)]
 pub struct RenderComponent {
     pub ascii_character: char,
+    pub rgb: Vector3<f32>,
 }
 impl Component for RenderComponent {
     const TYPE: ComponentType = ComponentType::Render;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -26,4 +26,5 @@ pub enum Key {
     Down,
     Space,
     Escape,
+    Q,
 }

--- a/src/wgpu/render.rs
+++ b/src/wgpu/render.rs
@@ -12,9 +12,11 @@ use wasm_bindgen::prelude::*;
 use wgpu::util::DeviceExt;
 use winit::{event_loop::ActiveEventLoop, keyboard::KeyCode, window::Window};
 
+#[derive(Default, Copy, Clone)]
 pub enum CameraStrategy {
-    CameraFollow(EntityId),
+    #[default]
     AllEntities,
+    CameraFollow(EntityId),
 }
 
 #[repr(C)]
@@ -742,8 +744,6 @@ impl State {
         let camera_x_position = (camera_points.0 + camera_points.1) as f32 / 2.0;
         let camera_y_position = (1 - camera_points.2 + camera_points.3) as f32 / 2.0;
 
-        let game_width = camera_points.1 - camera_points.0;
-        let z_depth = game_width as f32 / 8.1;
         match self.camera_strategy {
             CameraStrategy::CameraFollow(entity_id) => {
                 let entity = self
@@ -755,7 +755,7 @@ impl State {
                 self.camera.eye = cgmath::Point3::new(
                     camera_follow_position.x as f32 * 0.1,
                     camera_follow_position.y as f32 * 0.1,
-                    z_depth,
+                    4.0,
                 );
                 self.camera.target = cgmath::Point3::new(
                     camera_follow_position.x as f32 * 0.1,
@@ -765,6 +765,8 @@ impl State {
                 self.camera_uniform.update_view_proj(&self.camera);
             }
             CameraStrategy::AllEntities => {
+                let game_width = camera_points.1 - camera_points.0;
+                let z_depth = game_width as f32 / 8.1;
                 self.camera.eye =
                     cgmath::Point3::new(camera_x_position * 0.1, camera_y_position * 0.1, z_depth);
                 self.camera.target =

--- a/src/wgpu/render.rs
+++ b/src/wgpu/render.rs
@@ -303,34 +303,34 @@ impl InstanceColor {
 }
 
 pub struct State {
-    pub(crate) surface: wgpu::Surface<'static>,
-    pub(crate) device: wgpu::Device,
-    pub(crate) queue: wgpu::Queue,
-    pub(crate) config: wgpu::SurfaceConfiguration,
-    pub(crate) is_surface_configured: bool,
-    pub(crate) render_pipeline: wgpu::RenderPipeline,
-    pub(crate) vertex_buffer: wgpu::Buffer,
-    pub(crate) index_buffer: wgpu::Buffer,
-    pub(crate) num_indices: u32,
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    is_surface_configured: bool,
+    render_pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    num_indices: u32,
     #[allow(dead_code)]
-    pub(crate) diffuse_texture: texture::Texture,
-    pub(crate) diffuse_bind_group: wgpu::BindGroup,
-    pub(crate) instance_positions: Vec<InstancePosition>,
-    pub instance_colors: Vec<InstanceColor>,
-    pub(crate) instance_positions_buffer: wgpu::Buffer,
-    pub(crate) instance_colors_buffer: wgpu::Buffer,
-    pub camera_strategy: CameraStrategy,
+    diffuse_texture: texture::Texture,
+    diffuse_bind_group: wgpu::BindGroup,
+    instance_positions: Vec<InstancePosition>,
+    instance_colors: Vec<InstanceColor>,
+    instance_positions_buffer: wgpu::Buffer,
+    instance_colors_buffer: wgpu::Buffer,
+    camera_strategy: CameraStrategy,
 
-    pub(crate) vertices: Vec<Vertex>,
-    pub(crate) indices: Vec<u16>,
+    vertices: Vec<Vertex>,
+    indices: Vec<u16>,
 
-    pub(crate) camera: Camera,
-    pub(crate) camera_controller: CameraController,
-    pub(crate) camera_uniform: CameraUniform,
-    pub(crate) camera_buffer: wgpu::Buffer,
-    pub(crate) camera_bind_group: wgpu::BindGroup,
+    camera: Camera,
+    camera_controller: CameraController,
+    camera_uniform: CameraUniform,
+    camera_buffer: wgpu::Buffer,
+    camera_bind_group: wgpu::BindGroup,
     pub(crate) window: Arc<Window>,
-    pub(crate) renderable_entities: Vec<Entity>,
+    renderable_entities: Vec<Entity>,
 }
 
 impl State {
@@ -740,10 +740,10 @@ impl State {
                 acc
             });
         let camera_x_position = (camera_points.0 + camera_points.1) as f32 / 2.0;
-        let camera_y_position = (camera_points.2 + camera_points.3) as f32 / 2.0;
+        let camera_y_position = (1 - camera_points.2 + camera_points.3) as f32 / 2.0;
 
         let game_width = camera_points.1 - camera_points.0;
-        let z_depth = game_width as f32 / 7.8;
+        let z_depth = game_width as f32 / 8.1;
         match self.camera_strategy {
             CameraStrategy::CameraFollow(entity_id) => {
                 let entity = self

--- a/src/wgpu/runtime.rs
+++ b/src/wgpu/runtime.rs
@@ -1,6 +1,7 @@
 use crate::ecs::Entity;
 use crate::runtime::GameHandler;
 use crate::runtime::Key;
+use crate::wgpu::render::CameraStrategy;
 use crate::wgpu::render::State;
 use std::sync::Arc;
 #[cfg(target_arch = "wasm32")]
@@ -145,7 +146,6 @@ impl<'a> ApplicationHandler<State> for App<'a> {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            use crate::wgpu::render::CameraStrategy;
             self.render_state = Some(
                 pollster::block_on(State::new(
                     window,
@@ -162,7 +162,7 @@ impl<'a> ApplicationHandler<State> for App<'a> {
                 wasm_bindgen_futures::spawn_local(async move {
                     assert!(proxy
                         .send_event(
-                            State::new(window, game_entities)
+                            State::new(window, renderable_entities, CameraStrategy::AllEntities,)
                                 .await
                                 .expect("Unable to create canvas!!!")
                         )

--- a/src/wgpu/shader.wgsl
+++ b/src/wgpu/shader.wgsl
@@ -1,8 +1,12 @@
-struct InstanceInput {
+struct InstancePositionInput {
     @location(5) model_matrix_0: vec4<f32>,
     @location(6) model_matrix_1: vec4<f32>,
     @location(7) model_matrix_2: vec4<f32>,
     @location(8) model_matrix_3: vec4<f32>,
+};
+
+struct InstanceColorInput {
+    @location(9) model_matrix_0: vec3<f32>,
 };
 
 
@@ -15,7 +19,6 @@ var<uniform> camera: CameraUniform;
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
-    @location(1) color: vec3<f32>,
 };
 
 struct VertexOutput {
@@ -26,16 +29,18 @@ struct VertexOutput {
 @vertex
 fn vs_main(
     model: VertexInput,
-    instance: InstanceInput,
+    instance: InstancePositionInput,
+    instance_color: InstanceColorInput,
 ) -> VertexOutput {
+    var out: VertexOutput;
+    let color = instance_color.model_matrix_0;
     let model_matrix = mat4x4<f32>(
         instance.model_matrix_0,
         instance.model_matrix_1,
         instance.model_matrix_2,
         instance.model_matrix_3,
     );
-    var out: VertexOutput;
-    out.color = model.color;
+    out.color = color;
     out.clip_position = camera.view_proj * model_matrix * vec4<f32>(model.position, 1.0);
     return out;
 }


### PR DESCRIPTION
These changes:

1. introduce the option to add colour to rendered squres in wgpu mode (this requires a new instance colour buffer in wgpu)
2. add static camera which focuses on all existing game entities (see `CameraStrategy`)
3. fix a bug where unknown key in `hewn` throws an error if sent from either terminal/wgpu runtimes, instead we simply do nothing for now